### PR TITLE
See #6.  Add option to operate on integer dimensions.

### DIFF
--- a/dask_patternsearch/search.py
+++ b/dask_patternsearch/search.py
@@ -178,6 +178,10 @@ def search(client, func, x0, stepsize, args=(), max_queue_size=None, min_queue_s
             new_point = None
             new_cost = None
             cur_stepsize = to_grid(orientation * stepsize / 2.**cur_point.halvings)
+            if integer_dimensions is not None:
+                # Change the minimum step size for integers to 1
+                cur_stepsize[int_dims & (cur_stepsize < 0) & (cur_stepsize > -1)] = -1
+                cur_stepsize[int_dims & (cur_stepsize > 0) & (cur_stepsize < 1)] = 1
             cur_added = 0
             contract_conditions.clear()
             it = stencil.generate_stencil_points()

--- a/dask_patternsearch/tests/test_search.py
+++ b/dask_patternsearch/tests/test_search.py
@@ -73,7 +73,6 @@ def test_convergence_2d_integers(loop):
             assert best.result == min(x.result for x in results)
 
             best, results = search(client, sphere_p1, x0, stepsize, stopratio=stopratio, integer_dimensions=[0, 1])
-            print(sorted(results, key=lambda x: x.result))
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 

--- a/dask_patternsearch/tests/test_search.py
+++ b/dask_patternsearch/tests/test_search.py
@@ -9,6 +9,12 @@ from dask_patternsearch import search
 
 
 def sphere(x):
+    """Minimum at 0"""
+    return x.dot(x)
+
+def sphere_p1(x):
+    """Minimum at 0.1"""
+    x = x - 0.1
     return x.dot(x)
 
 
@@ -20,22 +26,54 @@ def test_convergence_2d_simple(loop):
             stopratio = 1e-2
             best, results = search(client, sphere, x0, stepsize, stopratio=stopratio)
             assert (np.abs(best.point) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
+
+            best, results = search(client, sphere_p1, x0, stepsize, stopratio=stopratio)
+            assert (np.abs(best.point - 0.1) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
 
             best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_queue_size=20)
             assert (np.abs(best.point) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
 
             best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_queue_size=1)
             assert (np.abs(best.point) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
 
             best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, min_new_submit=4)
             assert (np.abs(best.point) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
 
             best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_tasks=10)
             assert len(results) == 10
+            assert best.result == min(x.result for x in results)
 
             best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_stencil_size=4)
             assert (np.abs(best.point) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
 
             best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_stencil_size=4, min_new_submit=4)
             assert (np.abs(best.point) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
+
+
+def test_convergence_2d_integers(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as client:
+            x0 = np.array([10., 15])
+            stepsize = np.array([1., 1])
+            stopratio = 1e-2
+
+            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, integer_dimensions=[0])
+            assert (np.abs(best.point) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
+
+            best, results = search(client, sphere_p1, x0, stepsize, stopratio=stopratio, integer_dimensions=[0])
+            assert (np.abs(best.point - np.array([0, 0.1])) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
+
+            best, results = search(client, sphere_p1, x0, stepsize, stopratio=stopratio, integer_dimensions=[0, 1])
+            print(sorted(results, key=lambda x: x.result))
+            assert (np.abs(best.point) < 2*stopratio).all()
+            assert best.result == min(x.result for x in results)
 


### PR DESCRIPTION
We implement this somewhat simplistically: for integer dimensions, we round the step to the nearest integer away from 0.  The stepsize for integers are still halved (or doubled) with the step sizes for the rest of the dimensions.

Recall that the stencil that generates the steps for the trial points also contains the number of halvings to perform if that point is accepted.  If the step for a trial point is only along integer dimensions, then we no longer perform any halvings if that point is accepted (although it may still double).

Integer values are stored as floats with the rest of the coordinates, which I think is fine.

I don't know how robustly this will behave.  I guess we'll see.  To improve robustness, the suggestion remains the same: increase the queue size.