### PR TITLE
Create a simple client to run the algorithm in serial.  Partially solves #12

### DIFF
--- a/dask_patternsearch/clients.py
+++ b/dask_patternsearch/clients.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import, division, print_function
+
+from collections import deque
+from itertools import count
+
+import distributed
+
+
+class DaskClient(object):
+    """ A simple wrapper around ``distributed.Client`` to conform to our API"""
+    def __init__(self, client):
+        self._client = client
+        self._as_completed = distributed.as_completed([], with_results=True)
+
+    def submit(self, func, *args):
+        future = self._client.submit(func, *args)
+        self._as_completed.add(future)
+        return future
+
+    def has_results(self):
+        return not self._as_completed.queue.empty()
+
+    def next_batch(self, block=False):
+        return self._as_completed.next_batch(block=block)
+
+
+class SerialClient(object):
+    """ A simple client to run in serial.
+
+    This queues work until ``max_queue_size`` tasks have been submitted,
+    then it returns results one at a time.
+
+    """
+    def __init__(self):
+        self._queue = deque()
+        # For now, we use unique integers to mock future objects.  We don't
+        # do anything fancy with them.  We only use them as keys in a dict.
+        self._counter = count()
+
+    def submit(self, func, *args):
+        future = next(self._counter)
+        self._queue.append((future, func, args))
+        return future
+
+    def has_results(self):
+        return False
+
+    def next_batch(self, block=False):
+        if not block:
+            return ()
+        future, func, args = self._queue.popleft()
+        result = func(*args)
+        return ((future, result),)
+

--- a/dask_patternsearch/tests/test_search.py
+++ b/dask_patternsearch/tests/test_search.py
@@ -12,6 +12,7 @@ def sphere(x):
     """Minimum at 0"""
     return x.dot(x)
 
+
 def sphere_p1(x):
     """Minimum at 0.1"""
     x = x - 0.1
@@ -24,35 +25,35 @@ def test_convergence_2d_simple(loop):
             x0 = np.array([10., 15])
             stepsize = np.array([1., 1])
             stopratio = 1e-2
-            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio)
+            best, results = search(sphere, x0, stepsize, client=client, stopratio=stopratio)
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere_p1, x0, stepsize, stopratio=stopratio)
+            best, results = search(sphere_p1, x0, stepsize, client=client, stopratio=stopratio)
             assert (np.abs(best.point - 0.1) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_queue_size=20)
+            best, results = search(sphere, x0, stepsize, client=client, stopratio=stopratio, max_queue_size=20)
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_queue_size=1)
+            best, results = search(sphere, x0, stepsize, client=client, stopratio=stopratio, max_queue_size=1)
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, min_new_submit=4)
+            best, results = search(sphere, x0, stepsize, client=client, stopratio=stopratio, min_new_submit=4)
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_tasks=10)
+            best, results = search(sphere, x0, stepsize, client=client, stopratio=stopratio, max_tasks=10)
             assert len(results) == 10
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_stencil_size=4)
+            best, results = search(sphere, x0, stepsize, client=client, stopratio=stopratio, max_stencil_size=4)
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, max_stencil_size=4, min_new_submit=4)
+            best, results = search(sphere, x0, stepsize, client=client, stopratio=stopratio, max_stencil_size=4, min_new_submit=4)
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
@@ -64,15 +65,29 @@ def test_convergence_2d_integers(loop):
             stepsize = np.array([1., 1])
             stopratio = 1e-2
 
-            best, results = search(client, sphere, x0, stepsize, stopratio=stopratio, integer_dimensions=[0])
+            best, results = search(sphere, x0, stepsize, client=client, stopratio=stopratio, integer_dimensions=[0])
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere_p1, x0, stepsize, stopratio=stopratio, integer_dimensions=[0])
+            best, results = search(sphere_p1, x0, stepsize, client=client, stopratio=stopratio, integer_dimensions=[0])
             assert (np.abs(best.point - np.array([0, 0.1])) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
 
-            best, results = search(client, sphere_p1, x0, stepsize, stopratio=stopratio, integer_dimensions=[0, 1])
+            best, results = search(sphere_p1, x0, stepsize, client=client, stopratio=stopratio, integer_dimensions=[0, 1])
             assert (np.abs(best.point) < 2*stopratio).all()
             assert best.result == min(x.result for x in results)
+
+
+def test_convergence_2d_serial():
+    x0 = np.array([10., 15])
+    stepsize = np.array([1., 1])
+    stopratio = 1e-2
+
+    best, results = search(sphere, x0, stepsize, stopratio=stopratio)
+    assert (np.abs(best.point) < 2*stopratio).all()
+    assert best.result == min(x.result for x in results)
+
+    best, results = search(sphere_p1, x0, stepsize, stopratio=stopratio)
+    assert (np.abs(best.point - 0.1) < 2*stopratio).all()
+    assert best.result == min(x.result for x in results)
 


### PR DESCRIPTION
This gives us a simple API for our client object.  We wrap `dask.distributed.Client` to conform to this API.

`client=` is now an optional parameter to search.  If not provided, then the SerialClient will be used.

Also, the default `max_queue_size` was changed to 4 times the number of dimensions, or num_threads + num_workers (whichever is greater).  This seems like a reasonable default.